### PR TITLE
replace burnable with own lock method

### DIFF
--- a/contracts/ITablelandTables.sol
+++ b/contracts/ITablelandTables.sol
@@ -125,6 +125,20 @@ interface ITablelandTables {
     function getController(uint256 tableId) external returns (address);
 
     /**
+     * @dev Locks table ownership and access control _forever_.
+     *
+     * caller - the address that is locking the table
+     * tableId - the id of the target table
+     *
+     * Requirements:
+     *
+     * - contract must be unpaused
+     * - `msg.sender` must be `caller` and owner of `tableId`
+     * - `tableId` must exist
+     */
+    function lock(address caller, uint256 tableId) external;
+
+    /**
      * @dev Sets the contract base URI.
      *
      * baseURI - the new base URI

--- a/contracts/TablelandTables.sol
+++ b/contracts/TablelandTables.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.4;
 
 import "erc721a-upgradeable/contracts/ERC721AUpgradeable.sol";
 import "erc721a-upgradeable/contracts/extensions/ERC721AQueryableUpgradeable.sol";
-import "erc721a-upgradeable/contracts/extensions/ERC721ABurnableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
@@ -16,7 +15,6 @@ import "./ITablelandController.sol";
 contract TablelandTables is
     ITablelandTables,
     ERC721AUpgradeable,
-    ERC721ABurnableUpgradeable,
     ERC721AQueryableUpgradeable,
     OwnableUpgradeable,
     PausableUpgradeable,
@@ -35,7 +33,6 @@ contract TablelandTables is
         initializer
     {
         __ERC721A_init("Tableland Tables", "TABLE");
-        __ERC721ABurnable_init();
         __ERC721AQueryable_init();
         __Ownable_init();
         __Pausable_init();
@@ -164,6 +161,24 @@ contract TablelandTables is
         returns (address)
     {
         return _controllers[tableId];
+    }
+
+    /**
+     * @dev See {ITablelandTables-lock}.
+     */
+    function lock(address caller, uint256 tableId)
+        external
+        override
+        whenNotPaused
+    {
+        if (
+            !_exists(tableId) ||
+            !(caller == _msgSenderERC721A() && caller == ownerOf(tableId))
+        ) {
+            revert Unauthorized();
+        }
+
+        transferFrom(caller, address(this), tableId);
     }
 
     /**

--- a/contracts/test/TestTablelandController.sol
+++ b/contracts/test/TestTablelandController.sol
@@ -39,14 +39,14 @@ contract TestTablelandController is ITablelandController, Ownable {
         updatableColumns[0] = "baz";
 
         // Include a check on the incoming data
-        withChecks[0] = ""; // included to filter in Policies.joinClauses
+        withChecks[0] = ""; // included to touch all code branches in Policies.joinClauses
         withChecks[1] = "baz > 0";
-        withChecks[2] = ""; // included to filter in Policies.joinClauses
+        withChecks[2] = ""; // included to touch all code branches in Policies.joinClauses
 
         // Return policy
         return
             ITablelandController.Policy({
-                allowInsert: false,
+                allowInsert: true,
                 allowUpdate: true,
                 allowDelete: false,
                 whereClause: Policies.joinClauses(whereClauses),

--- a/contracts/test/TestTablelandTablesUpgrade.sol
+++ b/contracts/test/TestTablelandTablesUpgrade.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.4;
 
 import "erc721a-upgradeable/contracts/ERC721AUpgradeable.sol";
 import "erc721a-upgradeable/contracts/extensions/ERC721AQueryableUpgradeable.sol";
-import "erc721a-upgradeable/contracts/extensions/ERC721ABurnableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/security/PausableUpgradeable.sol";
@@ -13,7 +12,6 @@ import "../ITablelandController.sol";
 contract TestTablelandTablesUpgrade is
     ITablelandTables,
     ERC721AUpgradeable,
-    ERC721ABurnableUpgradeable,
     ERC721AQueryableUpgradeable,
     OwnableUpgradeable,
     PausableUpgradeable,
@@ -30,7 +28,6 @@ contract TestTablelandTablesUpgrade is
         initializer
     {
         __ERC721A_init("Tableland Tables", "TABLE");
-        __ERC721ABurnable_init();
         __ERC721AQueryable_init();
         __Ownable_init();
         __Pausable_init();
@@ -111,6 +108,12 @@ contract TestTablelandTablesUpgrade is
         view
         override
         returns (address)
+    {} // solhint-disable no-empty-blocks
+
+    function lock(address caller, uint256 tableId)
+        external
+        override
+        whenNotPaused
     {} // solhint-disable no-empty-blocks
 
     // solhint-disable-next-line no-empty-blocks

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "build": "npx tsc -p ./tsconfig.build.json",
     "up": "npm install && npx hardhat compile && npm run build && hardhat node",
-    "test": "hardhat coverage && istanbul check-coverage ./coverage.json --statements 100 --branches 97 --functions 100 --lines 100",
+    "test": "hardhat coverage && istanbul check-coverage ./coverage.json --statements 100 --branches 98 --functions 100 --lines 100",
     "lint": "eslint '**/*.{js,ts}'",
     "lint:fix": "npm run lint -- --fix",
     "prettier": "prettier '**/*.{ts,json,sol,md}' --check",

--- a/test/ITablelandController.ts
+++ b/test/ITablelandController.ts
@@ -92,9 +92,7 @@ describe("ITablelandController", function () {
       .setController(owner.address, tableId, eoaController.address);
     receipt = await tx.wait();
     let [setControllerEvent] = receipt.events ?? [];
-    expect(setControllerEvent.args!.tableId).to.equal(
-      createEvent.args!.tableId
-    );
+    expect(setControllerEvent.args!.tableId).to.equal(tableId);
     expect(setControllerEvent.args!.controller).to.equal(eoaController.address);
 
     // Test that runSQL is now locked down to this EOA address
@@ -114,9 +112,7 @@ describe("ITablelandController", function () {
       .setController(owner.address, tableId, allowAllController.address);
     receipt = await tx.wait();
     [setControllerEvent] = receipt.events ?? [];
-    expect(setControllerEvent.args!.tableId).to.equal(
-      createEvent.args!.tableId
-    );
+    expect(setControllerEvent.args!.tableId).to.equal(tableId);
     expect(setControllerEvent.args!.controller).to.equal(
       allowAllController.address
     );
@@ -230,7 +226,7 @@ describe("ITablelandController", function () {
     expect(runEvent.args!.isOwner).to.equal(false);
     expect(runEvent.args!.tableId).to.equal(tableId);
     expect(runEvent.args!.statement).to.equal(runStatement);
-    expect(runEvent.args!.policy.allowInsert).to.equal(false);
+    expect(runEvent.args!.policy.allowInsert).to.equal(true);
     expect(runEvent.args!.policy.allowUpdate).to.equal(true);
     expect(runEvent.args!.policy.allowDelete).to.equal(false);
     expect(runEvent.args!.policy.whereClause).to.equal(
@@ -258,7 +254,7 @@ describe("ITablelandController", function () {
     expect(runEvent.args!.isOwner).to.equal(false);
     expect(runEvent.args!.tableId).to.equal(tableId);
     expect(runEvent.args!.statement).to.equal(runStatement);
-    expect(runEvent.args!.policy.allowInsert).to.equal(false);
+    expect(runEvent.args!.policy.allowInsert).to.equal(true);
     expect(runEvent.args!.policy.allowUpdate).to.equal(true);
     expect(runEvent.args!.policy.allowDelete).to.equal(false);
     expect(runEvent.args!.policy.whereClause).to.equal(


### PR DESCRIPTION
Replaces `ERC721ABurnableUpgradeable` with a custom lock method that leaves the table operational but with ownership and access control unchangeable.