### PR TITLE
publish declaration files for proxies.js

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableland/evm",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableland/evm",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "MIT AND Apache-2.0",
       "devDependencies": {
         "@ethersproject/providers": "^5.6.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tableland/evm",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Tableland Tables EVM contracts and client components",
   "engines": {
     "node": ">=14.0.0"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "main": "typechain-types/index.js",
   "types": "typechain-types/index.d.ts",
   "files": [
-    "proxies.js",
+    "proxies.*",
     "contracts",
     "typechain-types/**/*.js?(.map)",
     "typechain-types/**/*.d.ts"


### PR DESCRIPTION
The js-tableland build fails because we weren't publishing proxies.d.ts and proxies.ts.  `npm link` makes those available so I didn't notice until I did the actual publish