### PR TITLE
Fix check for setController and lockController

### DIFF
--- a/contracts/TablelandTables.sol
+++ b/contracts/TablelandTables.sol
@@ -146,8 +146,14 @@ contract TablelandTables is
         address controller
     ) external override whenNotPaused {
         if (
+            // table doesn't exist or
             !_exists(tableId) ||
-            !(caller == _msgSenderERC721A() && caller == ownerOf(tableId)) ||
+            // message sender is not (caller or contract owner) or
+            !(caller == _msgSenderERC721A() ||
+                owner() == _msgSenderERC721A()) ||
+            // caller is not table owner or
+            caller != ownerOf(tableId) ||
+            // table is locked
             _locks[tableId]
         ) {
             revert Unauthorized();
@@ -179,8 +185,14 @@ contract TablelandTables is
         whenNotPaused
     {
         if (
+            // table doesn't exist or
             !_exists(tableId) ||
-            !(caller == _msgSenderERC721A() && caller == ownerOf(tableId)) ||
+            // message sender is not (caller or contract owner) or
+            !(caller == _msgSenderERC721A() ||
+                owner() == _msgSenderERC721A()) ||
+            // caller is not table owner or
+            caller != ownerOf(tableId) ||
+            // table is locked
             _locks[tableId]
         ) {
             revert Unauthorized();

--- a/contracts/TablelandTables.sol
+++ b/contracts/TablelandTables.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
+import "hardhat/console.sol";
 import "erc721a-upgradeable/contracts/ERC721AUpgradeable.sol";
 import "erc721a-upgradeable/contracts/extensions/ERC721AQueryableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/proxy/utils/UUPSUpgradeable.sol";
@@ -145,17 +146,22 @@ contract TablelandTables is
         uint256 tableId,
         address controller
     ) external override whenNotPaused {
+        // table doesn't exist or
+        if (!_exists(tableId)) {
+            revert Unauthorized();
+        }
+        // message sender is not (caller or contract owner) or
         if (
-            // table doesn't exist or
-            !_exists(tableId) ||
-            // message sender is not (caller or contract owner) or
-            !(caller == _msgSenderERC721A() ||
-                owner() == _msgSenderERC721A()) ||
-            // caller is not table owner or
-            caller != ownerOf(tableId) ||
-            // table is locked
-            _locks[tableId]
+            !(caller == _msgSenderERC721A() || owner() == _msgSenderERC721A())
         ) {
+            revert Unauthorized();
+        }
+        // caller is not table owner or
+        if (caller != ownerOf(tableId)) {
+            revert Unauthorized();
+        }
+        // table is locked
+        if (_locks[tableId]) {
             revert Unauthorized();
         }
 
@@ -184,17 +190,22 @@ contract TablelandTables is
         override
         whenNotPaused
     {
+        // table doesn't exist or
+        if (!_exists(tableId)) {
+            revert Unauthorized();
+        }
+        // message sender is not (caller or contract owner) or
         if (
-            // table doesn't exist or
-            !_exists(tableId) ||
-            // message sender is not (caller or contract owner) or
-            !(caller == _msgSenderERC721A() ||
-                owner() == _msgSenderERC721A()) ||
-            // caller is not table owner or
-            caller != ownerOf(tableId) ||
-            // table is locked
-            _locks[tableId]
+            !(caller == _msgSenderERC721A() || owner() == _msgSenderERC721A())
         ) {
+            revert Unauthorized();
+        }
+        // caller is not table owner or
+        if (caller != ownerOf(tableId)) {
+            revert Unauthorized();
+        }
+        // table is locked
+        if (_locks[tableId]) {
             revert Unauthorized();
         }
 

--- a/proxies.d.ts.map
+++ b/proxies.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"proxies.d.ts","sourceRoot":"","sources":["proxies.ts"],"names":[],"mappings":"AAAA,MAAM,WAAW,cAAc;IAC7B,CAAC,GAAG,EAAE,MAAM,GAAG,MAAM,CAAA;CACtB;AAED,eAAO,MAAM,OAAO,EAAE,cAYrB,CAAC"}
+{"version":3,"file":"proxies.d.ts","sourceRoot":"","sources":["proxies.ts"],"names":[],"mappings":"AAAA,MAAM,WAAW,cAAc;IAC7B,CAAC,GAAG,EAAE,MAAM,GAAG,MAAM,CAAC;CACvB;AAED,eAAO,MAAM,OAAO,EAAE,cAYrB,CAAC"}

--- a/test/TablelandTables.ts
+++ b/test/TablelandTables.ts
@@ -271,4 +271,94 @@ describe("TablelandTables", function () {
     await expect(tableId instanceof BigNumber).to.equal(true);
     await expect(tableId.toNumber()).to.equal(1);
   });
+
+  it("Should be able to set controller", async function () {
+    const owner = accounts[4];
+    const createStatement = "create table testing (int a);";
+    let tx = await tables
+      .connect(owner)
+      .createTable(owner.address, createStatement);
+    await tx.wait();
+
+    // Test owner setting controller
+    tx = await tables
+      .connect(owner)
+      .setController(owner.address, BigNumber.from(1), accounts[5].address);
+    await tx.wait();
+
+    let controller = await tables
+      .connect(owner)
+      .getController(BigNumber.from(1));
+
+    expect(controller).to.equal(accounts[5].address);
+
+    // Test conract owner setting controller on behalf of owner
+    const contractOwner = accounts[0];
+    tx = await tables
+      .connect(contractOwner)
+      .setController(owner.address, BigNumber.from(1), accounts[6].address);
+    await tx.wait();
+
+    controller = await tables.connect(owner).getController(BigNumber.from(1));
+
+    expect(controller).to.equal(accounts[6].address);
+  });
+
+  it("Should reject when setting controller not allowed", async function () {
+    const owner = accounts[4];
+    const createStatement = "create table testing (int a);";
+    let tx = await tables
+      .connect(owner)
+      .createTable(owner.address, createStatement);
+    await tx.wait();
+
+    tx = await tables
+      .connect(owner)
+      .setController(owner.address, BigNumber.from(1), accounts[5].address);
+    await tx.wait();
+
+    // Test setting controller on table that doesn't exist
+    await expect(
+      tables
+        .connect(owner)
+        .setController(owner.address, BigNumber.from(1001), accounts[5].address)
+    ).to.be.revertedWith("Unauthorized");
+
+    const contractOwner = accounts[0];
+    // Test setting controller on table not owned by caller
+    await expect(
+      tables
+        .connect(contractOwner)
+        .setController(
+          accounts[7].address,
+          BigNumber.from(1),
+          accounts[5].address
+        )
+    ).to.be.revertedWith("Unauthorized");
+
+    // Test locking controller on table not owned by caller
+    await expect(
+      tables
+        .connect(contractOwner)
+        .lockController(accounts[7].address, BigNumber.from(1))
+    ).to.be.revertedWith("Unauthorized");
+
+    // lock controller
+    tx = await tables
+      .connect(owner)
+      .lockController(owner.address, BigNumber.from(1));
+    await tx.wait();
+
+    // Test setting controller when locked
+    await expect(
+      tables
+        .connect(owner)
+        .setController(owner.address, BigNumber.from(1), accounts[5].address)
+    ).to.be.revertedWith("Unauthorized");
+
+    // Test relocking controller when locked
+    await expect(
+      tables.connect(owner).lockController(owner.address, BigNumber.from(1))
+    ).to.be.revertedWith("Unauthorized");
+  });
 });


### PR DESCRIPTION
This fixes an issue with the authorization checks that prevents the Validator from relaying calls to `setController` and `lockController`