### PR TITLE
2.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableland/evm",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableland/evm",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "MIT AND Apache-2.0",
       "devDependencies": {
         "@ethersproject/providers": "^5.6.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tableland/evm",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Tableland Tables EVM contracts and client components",
   "engines": {
     "node": ">=14.0.0"


### PR DESCRIPTION
Merge release into main.
Now that we don't allow direct pushes to main I wasn't able to do npm version ... then git push origin main. When we implement changes like https://github.com/tablelandnetwork/js-tableland/issues/68 in this repo this kind of pr shouldn't be needed anymore