### PR TITLE
refactor: update 'toCreateFromSchema'

### DIFF
--- a/contracts/utils/SQLHelpers.sol
+++ b/contracts/utils/SQLHelpers.sol
@@ -37,14 +37,14 @@ library SQLHelpers {
     /**
      * @dev Generates a CREATE statement based on a desired schema and table prefix.
      *
-     * prefix - the user generated table prefix as a string
      * schema - a comma seperated string indicating the desired prefix. Example: "int id, text name"
+     * prefix - the user generated table prefix as a string
      *
      * Requirements:
      *
      * - block.chainid must refer to a supported chain.
      */
-    function toCreateFromSchema(string memory prefix, string memory schema)
+    function toCreateFromSchema(string memory schema, string memory prefix)
         public
         view
         returns (string memory)

--- a/test/utils/SQLHelpers.ts
+++ b/test/utils/SQLHelpers.ts
@@ -25,7 +25,7 @@ describe("SQLHelpers", function () {
   it("Should return a valid CREATE statement from schema", async function () {
     await expect(
       // This is not a valid name in Tableland but tests string concat.
-      await lib.toCreateFromSchema("test_101", "id int, name text, desc text")
+      await lib.toCreateFromSchema("id int, name text, desc text", "test_101")
     ).to.equal("CREATE TABLE test_101_31337 (id int, name text, desc text)");
   });
 


### PR DESCRIPTION
The SDK and CLI take params `schema` and `prefix` in that order -- thus, this helper should do the same. The current method params are `toCreateFromSchema(string memory prefix, string memory schema)`, so this PR just flips them and reflects this in the associated hardhat test script.