### PR TITLE
Publish the deploy script to npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableland/evm",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableland/evm",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "MIT AND Apache-2.0",
       "devDependencies": {
         "@ethersproject/providers": "^5.6.8",

--- a/package.json
+++ b/package.json
@@ -11,12 +11,14 @@
     "network.*",
     "contracts",
     "typechain-types/**/*.js?(.map)",
-    "typechain-types/**/*.d.ts"
+    "typechain-types/**/*.d.ts",
+    "scripts"
   ],
   "exports": {
     ".": "./typechain-types/index.js",
     "./network.js": "./network.js",
-    "./contracts/": "./contracts/"
+    "./contracts/": "./contracts/",
+    "./scripts/deploy.ts": "./scripts/deploy.ts"
   },
   "scripts": {
     "build": "hardhat compile && npx tsc -p ./tsconfig.build.json",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tableland/evm",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Tableland Tables EVM contracts and client components",
   "engines": {
     "node": ">=14.0.0"

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -56,7 +56,7 @@ async function main() {
   console.log("Healthbot table updated with:", runEvent.args?.statement);
 
   // Warn that proxy address needs to be saved in config
-  console.warn(
+  console.log(
     `\nSave 'proxies.${network.name}: "${tables.address}"' in 'network.ts'!`
   );
 }


### PR DESCRIPTION
These changes so that we publish the deploy script to npm so that local tableland can use it during start up without cloning this entire repo.   There's also a small change so that the proxy contract address logging is sent to stdout instead of stderr.  Sending it to stderr was crashing the deployment subprocess of local-tableland.