### PR TITLE
Update build and publish files for local-tableland

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,10 @@ bytecode.bin
 gobuild
 network.d*
 network.js*
+hardhat.config.d*
+hardhat.config.js*
+scripts/*.d*
+scripts/*.js*
 
 # Hardhat files
 cache

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableland/evm",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableland/evm",
-      "version": "3.0.1",
+      "version": "3.0.2",
       "license": "MIT AND Apache-2.0",
       "devDependencies": {
         "@ethersproject/providers": "^5.6.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tableland/evm",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Tableland Tables EVM contracts and client components",
   "engines": {
     "node": ">=14.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tableland/evm",
-  "version": "3.0.1-next3.0.2",
+  "version": "3.0.1",
   "description": "Tableland Tables EVM contracts and client components",
   "engines": {
     "node": ">=14.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tableland/evm",
-  "version": "3.0.1",
+  "version": "3.0.1-next3.0.2",
   "description": "Tableland Tables EVM contracts and client components",
   "engines": {
     "node": ">=14.0.0"
@@ -9,6 +9,7 @@
   "types": "typechain-types/index.d.ts",
   "files": [
     "network.*",
+    "hardhat.config.*",
     "contracts",
     "typechain-types/**/*.js?(.map)",
     "typechain-types/**/*.d.ts",
@@ -16,9 +17,9 @@
   ],
   "exports": {
     ".": "./typechain-types/index.js",
-    "./network.js": "./network.js",
+    "./network": "./network.js",
     "./contracts/": "./contracts/",
-    "./scripts/deploy.ts": "./scripts/deploy.ts"
+    "./scripts/deploy.js": "./scripts/deploy.js"
   },
   "scripts": {
     "build": "hardhat compile && npx tsc -p ./tsconfig.build.json",

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -8,6 +8,6 @@
     "declarationMap": true,
     "skipLibCheck": true
   },
-  "include": ["./typechain-types/**/*"],
-  "files": ["network.ts"]
+  "include": ["./typechain-types/**/*", "./scripts/**/*"],
+  "files": ["network.ts", "hardhat.config.ts"]
 }


### PR DESCRIPTION
In order for the local-tableland npm module `@tableland/local` to include this module as a dependency, then import and run the script to deploy the registry contract we need to transpile and publish the hardhat config as well as the deploy script.
