### PR TITLE
Add local-tableland registry contract address

### DIFF
--- a/network.ts
+++ b/network.ts
@@ -18,8 +18,9 @@ export interface TablelandNetworkConfig {
 }
 
 const homesteadAddr = "0x012969f7e3439a9B04025b5a049EB9BAD82A8C12";
-// When running local-tableland network the proxy address will be "0xe7f1725e7734ce288f8367e1bb143e90bb3f0512"
-const localTablelandAddr = "";
+// When running local-tableland network the proxy address will always be
+// "0xe7f1725e7734ce288f8367e1bb143e90bb3f0512" because of the order of contract deployment
+const localTablelandAddr = "0xe7f1725e7734ce288f8367e1bb143e90bb3f0512";
 export const proxies: TablelandNetworkConfig = {
   mainnet: homesteadAddr,
   homestead: homesteadAddr,

--- a/network.ts
+++ b/network.ts
@@ -18,9 +18,7 @@ export interface TablelandNetworkConfig {
 }
 
 const homesteadAddr = "0x012969f7e3439a9B04025b5a049EB9BAD82A8C12";
-// When running local-tableland network the proxy address will always be
-// "0xe7f1725e7734ce288f8367e1bb143e90bb3f0512" because of the order of contract deployment
-const localTablelandAddr = "0xe7f1725e7734ce288f8367e1bb143e90bb3f0512";
+
 export const proxies: TablelandNetworkConfig = {
   mainnet: homesteadAddr,
   homestead: homesteadAddr,
@@ -32,8 +30,11 @@ export const proxies: TablelandNetworkConfig = {
   "arbitrum-goerli": "0x033f69e8d119205089Ab15D340F5b797732f646b",
   maticmum: "0x4b48841d4b32C4650E4ABc117A03FE8B51f38F68",
   "optimism-goerli-staging": "0xfe79824f6E5894a3DD86908e637B7B4AF57eEE28",
-  localhost: localTablelandAddr,
-  "local-tableland": localTablelandAddr,
+  // localhost is a stand alone node
+  localhost: "",
+  // local-tableland implies that a validator is also running. the proxy address will always be
+  // "0xe7f1725e7734ce288f8367e1bb143e90bb3f0512" because of the order of contract deployment
+  "local-tableland": "0xe7f1725e7734ce288f8367e1bb143e90bb3f0512",
 };
 
 const homesteadURI = "https://tableland.network/api/v1/tables/1/";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tableland/evm",
-  "version": "4.0.0-pre.1",
+  "version": "4.0.0-pre.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@tableland/evm",
-      "version": "4.0.0-pre.1",
+      "version": "4.0.0-pre.2",
       "license": "MIT AND Apache-2.0",
       "devDependencies": {
         "@ethersproject/providers": "^5.6.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tableland/evm",
-  "version": "4.0.0-pre.1",
+  "version": "4.0.0-pre.2",
   "description": "Tableland Tables EVM contracts and client components",
   "engines": {
     "node": ">=14.0.0"


### PR DESCRIPTION
This will set the default registry address for a local hardhat network to the value for local-tableland's registry.
After some discussion and usage feedback it seems that this will alleviate some headaches and boiler plate code for devs and automated testing.