### PR TITLE
fix missing source from published files

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "hardhat.config.*",
     "contracts",
     "typechain-types/**/*.js?(.map)",
-    "typechain-types/**/*.d.ts",
+    "typechain-types/**/*.ts",
     "scripts"
   ],
   "exports": {


### PR DESCRIPTION
This is a fix for https://github.com/tablelandnetwork/js-tableland/issues/355
This package is publishing source map files but not the source.  This causes warnings in consumers like React Apps.  We can potentially remove the map files, but our other packages publish maps and source so it seems natural to do that here.
cc: @carsonfarmer @dtbuchholz 