### PR TITLE
Add TableId to "getPolicy" method V2

### DIFF
--- a/contracts/ITablelandController.sol
+++ b/contracts/ITablelandController.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.4;
 
+import "./TablelandPolicy.sol";
+
 /**
  * @dev Interface of a TablelandController compliant contract.
  *
@@ -11,33 +13,10 @@ pragma solidity ^0.8.4;
  */
 interface ITablelandController {
     /**
-     * @dev Object defining how a table can be accessed.
+     * @dev Returns a {TablelandPolicy} struct defining how a table can be accessed by `caller`.
      */
-    struct Policy {
-        // Whether or not the table should allow SQL INSERT statements.
-        bool allowInsert;
-        // Whether or not the table should allow SQL UPDATE statements.
-        bool allowUpdate;
-        // Whether or not the table should allow SQL DELETE statements.
-        bool allowDelete;
-        // A conditional clause used with SQL UPDATE and DELETE statements.
-        // For example, a value of "foo > 0" will concatenate all SQL UPDATE
-        // and/or DELETE statements with "WHERE foo > 0".
-        // This can be useful for limiting how a table can be modified.
-        // Use {Policies-joinClauses} to include more than one condition.
-        string whereClause;
-        // A conditional clause used with SQL INSERT statements.
-        // For example, a value of "foo > 0" will concatenate all SQL INSERT
-        // statements with a check on the incoming data, i.e., "CHECK (foo > 0)".
-        // This can be useful for limiting how table data ban be added.
-        // Use {Policies-joinClauses} to include more than one condition.
-        string withCheck;
-        // A list of SQL column names that can be updated.
-        string[] updatableColumns;
-    }
-
-    /**
-     * @dev Returns a {Policy} struct defining how a table can be accessed by `caller`.
-     */
-    function getPolicy(address caller) external payable returns (Policy memory);
+    function getPolicy(
+        address caller,
+        uint256 tableId
+    ) external payable returns (TablelandPolicy memory);
 }

--- a/contracts/ITablelandControllerV0.sol
+++ b/contracts/ITablelandControllerV0.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+import "./TablelandPolicy.sol";
+
+/**
+ * @dev Interface of a v0 TablelandController compliant contract.
+ */
+interface ITablelandControllerV0 {
+    /**
+     * @dev Returns a {Policy} struct defining how a table can be accessed by `caller`.
+     */
+    function getPolicy(
+        address caller
+    ) external payable returns (TablelandPolicy memory);
+}

--- a/contracts/ITablelandControllerV0.sol
+++ b/contracts/ITablelandControllerV0.sol
@@ -8,7 +8,7 @@ import "./TablelandPolicy.sol";
  */
 interface ITablelandControllerV0 {
     /**
-     * @dev Returns a {Policy} struct defining how a table can be accessed by `caller`.
+     * @dev Returns a {TablelandPolicy} struct defining how a table can be accessed by `caller`.
      */
     function getPolicy(
         address caller

--- a/contracts/ITablelandTables.sol
+++ b/contracts/ITablelandTables.sol
@@ -46,7 +46,7 @@ interface ITablelandTables {
      * isOwner - whether or not the caller is the table owner
      * tableId - the id of the target table
      * statement - the SQL statement to run
-     * policy - an object describing how `caller` can interact with the table (see {ITablelandController.Policy})
+     * policy - an object describing how `caller` can interact with the table (see {TablelandPolicy})
      */
     event RunSQL(
         address caller,

--- a/contracts/ITablelandTables.sol
+++ b/contracts/ITablelandTables.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.4;
 
 import "./ITablelandController.sol";
+import "./TablelandPolicy.sol";
 
 /**
  * @dev Interface of a TablelandTables compliant contract.
@@ -52,7 +53,7 @@ interface ITablelandTables {
         bool isOwner,
         uint256 tableId,
         string statement,
-        ITablelandController.Policy policy
+        TablelandPolicy policy
     );
 
     /**

--- a/contracts/TablelandPolicy.sol
+++ b/contracts/TablelandPolicy.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+/**
+ * @dev Object defining how a table can be accessed.
+ */
+struct TablelandPolicy {
+    // Whether or not the table should allow SQL INSERT statements.
+    bool allowInsert;
+    // Whether or not the table should allow SQL UPDATE statements.
+    bool allowUpdate;
+    // Whether or not the table should allow SQL DELETE statements.
+    bool allowDelete;
+    // A conditional clause used with SQL UPDATE and DELETE statements.
+    // For example, a value of "foo > 0" will concatenate all SQL UPDATE
+    // and/or DELETE statements with "WHERE foo > 0".
+    // This can be useful for limiting how a table can be modified.
+    // Use {Policies-joinClauses} to include more than one condition.
+    string whereClause;
+    // A conditional clause used with SQL INSERT statements.
+    // For example, a value of "foo > 0" will concatenate all SQL INSERT
+    // statements with a check on the incoming data, i.e., "CHECK (foo > 0)".
+    // This can be useful for limiting how table data ban be added.
+    // Use {Policies-joinClauses} to include more than one condition.
+    string withCheck;
+    // A list of SQL column names that can be updated.
+    string[] updatableColumns;
+}

--- a/contracts/interfaces/ITablelandControllerV0.sol
+++ b/contracts/interfaces/ITablelandControllerV0.sol
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.4;
+
+import "../ITablelandControllerV0.sol";

--- a/contracts/policies/ERC721AQueryablePolicies.sol
+++ b/contracts/policies/ERC721AQueryablePolicies.sol
@@ -5,7 +5,7 @@ import "erc721a/contracts/extensions/ERC721AQueryable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/StringsUpgradeable.sol";
 
 /**
- * @dev Library containing {ERC721AQueryable}-related helper methods for writing {ITablelandController.Policy}s.
+ * @dev Library containing {ERC721AQueryable}-related helper methods for writing {TablelandPolicy}s.
  */
 library ERC721AQueryablePolicies {
     /**
@@ -18,7 +18,7 @@ library ERC721AQueryablePolicies {
      * equal to `target` {ERC721AQueryable} tokens owned by `caller`.
      *
      * Useful when you want to restict table INSERT / UPDATE / DELETE to owners of a given NFT collection.
-     * Intented to be used with {ITablelandController.Policy}'s `whereClause` or `withCheck` fields.
+     * Intented to be used with {TablelandPolicy}'s `whereClause` or `withCheck` fields.
      *
      * caller - the address that the policy if for
      * tableId - the address of the {ERC721AQueryable} token that `caller` must be an owner of

--- a/contracts/policies/ERC721EnumerablePolicies.sol
+++ b/contracts/policies/ERC721EnumerablePolicies.sol
@@ -5,7 +5,7 @@ import "@openzeppelin/contracts/token/ERC721/extensions/ERC721Enumerable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/StringsUpgradeable.sol";
 
 /**
- * @dev Library containing {ERC721Enumerable}-related helper methods for writing {ITablelandController.Policy}s.
+ * @dev Library containing {ERC721Enumerable}-related helper methods for writing {TablelandPolicy}s.
  */
 library ERC721EnumerablePolicies {
     /**
@@ -18,7 +18,7 @@ library ERC721EnumerablePolicies {
      * equal to `target` {ERC721Enumerable} tokens owned by `caller`.
      *
      * Useful when you want to restict table INSERT / UPDATE / DELETE to owners of a given NFT collection.
-     * Intented to be used with {ITablelandController.Policy}'s `whereClause` or `withCheck` fields.
+     * Intented to be used with {TablelandPolicy}'s `whereClause` or `withCheck` fields.
      *
      * caller - the address that the policy if for
      * tableId - the address of the {ERC721Enumerable} token that `caller` must be an owner of

--- a/contracts/policies/Policies.sol
+++ b/contracts/policies/Policies.sol
@@ -2,11 +2,11 @@
 pragma solidity ^0.8.4;
 
 /**
- * @dev Library containing {ITablelandController.Policy} helper methods.
+ * @dev Library containing {TablelandPolicy} helper methods.
  */
 library Policies {
     /**
-     * @dev Joins multiple conditional clauses for {ITablelandController.Policy}'s `whereClause` and `withCheck` fields.
+     * @dev Joins multiple conditional clauses for {TablelandPolicy}'s `whereClause` and `withCheck` fields.
      */
     function joinClauses(
         string[] memory clauses

--- a/contracts/test/TestAllowAllTablelandController.sol
+++ b/contracts/test/TestAllowAllTablelandController.sol
@@ -2,17 +2,19 @@
 pragma solidity ^0.8.4;
 
 import "../ITablelandController.sol";
+import "../TablelandPolicy.sol";
 import "../policies/Policies.sol";
 import "../policies/ERC721EnumerablePolicies.sol";
 import "../policies/ERC721AQueryablePolicies.sol";
 
 contract TestAllowAllTablelandController is ITablelandController {
     function getPolicy(
-        address
-    ) public payable override returns (ITablelandController.Policy memory) {
+        address,
+        uint256
+    ) public payable override returns (TablelandPolicy memory) {
         // Return allow-all policy
         return
-            ITablelandController.Policy({
+            TablelandPolicy({
                 allowInsert: true,
                 allowUpdate: true,
                 allowDelete: true,

--- a/contracts/test/TestTablelandControllerV0.sol
+++ b/contracts/test/TestTablelandControllerV0.sol
@@ -2,13 +2,27 @@
 pragma solidity ^0.8.4;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
-import "../ITablelandController.sol";
-import "../TablelandPolicy.sol";
 import "../policies/Policies.sol";
 import "../policies/ERC721EnumerablePolicies.sol";
 import "../policies/ERC721AQueryablePolicies.sol";
 
-contract TestTablelandController is ITablelandController, Ownable {
+/**
+ * @dev This is an exact copy of the original ITablelandController, maintained here to ensure backwards compatibility.
+ */
+interface ITablelandControllerV0Test {
+    struct Policy {
+        bool allowInsert;
+        bool allowUpdate;
+        bool allowDelete;
+        string whereClause;
+        string withCheck;
+        string[] updatableColumns;
+    }
+
+    function getPolicy(address caller) external payable returns (Policy memory);
+}
+
+contract TestTablelandControllerV0 is ITablelandControllerV0Test, Ownable {
     error InsufficientValue(uint256 receivedValue, uint256 requiredValue);
 
     uint256 public constant REQUIRED_VALUE = 1 ether;
@@ -17,16 +31,12 @@ contract TestTablelandController is ITablelandController, Ownable {
     address private _bars;
 
     function getPolicy(
-        address caller,
-        uint256
-    ) public payable override returns (TablelandPolicy memory) {
+        address caller
+    ) public payable override returns (Policy memory) {
         // Enforce some ether and revert if insufficient
-        if (msg.value < 1 ether) {
+        if (msg.value != 1 ether) {
             revert InsufficientValue(msg.value, REQUIRED_VALUE);
         }
-
-        // The following line is for coverage of a revert/require error
-        require(msg.value == 1 ether, "too much ether!");
 
         string[] memory whereClauses = new string[](2);
         string[] memory withChecks = new string[](3);
@@ -56,7 +66,7 @@ contract TestTablelandController is ITablelandController, Ownable {
 
         // Return policy
         return
-            TablelandPolicy({
+            Policy({
                 allowInsert: false,
                 allowUpdate: true,
                 allowDelete: false,

--- a/test/unit/ITablelandController.ts
+++ b/test/unit/ITablelandController.ts
@@ -8,6 +8,7 @@ import type {
   TestERC721Enumerable,
   TestERC721AQueryable,
   TestTablelandController,
+  TestTablelandControllerV0,
   TestAllowAllTablelandController,
   ERC721EnumerablePolicies,
   ERC721AQueryablePolicies,
@@ -24,6 +25,7 @@ describe("ITablelandController", function () {
   let enumPolicyLib: ERC721EnumerablePolicies;
   let queryablePolicyLib: ERC721AQueryablePolicies;
   let controller: TestTablelandController;
+  let controllerV0: TestTablelandControllerV0;
   let allowAllController: TestAllowAllTablelandController;
 
   beforeEach(async function () {
@@ -64,14 +66,21 @@ describe("ITablelandController", function () {
     ).deploy()) as TestTablelandController;
     await controller.deployed();
 
+    controllerV0 = (await (
+      await ethers.getContractFactory("TestTablelandControllerV0")
+    ).deploy()) as TestTablelandControllerV0;
+    await controllerV0.deployed();
+
     allowAllController = (await (
       await ethers.getContractFactory("TestAllowAllTablelandController")
     ).deploy()) as TestAllowAllTablelandController;
     await allowAllController.deployed();
 
-    // Setup controller
+    // Setup controllers
     await (await controller.setFoos(foos.address)).wait();
     await (await controller.setBars(bars.address)).wait();
+    await (await controllerV0.setFoos(foos.address)).wait();
+    await (await controllerV0.setBars(bars.address)).wait();
   });
 
   it("Should set controller for a table", async function () {
@@ -298,12 +307,19 @@ describe("ITablelandController", function () {
       .setController(owner.address, tableId, controller.address);
     await tx.wait();
 
-    // Test that run SQL on table is gated by ether
+    // Test that run SQL on table is gated by ether (with custom error)
     const runStatement = "insert into testing values (0);";
     const caller = accounts[5];
     await expect(
       tables.connect(caller).runSQL(caller.address, tableId, runStatement)
     ).to.be.revertedWithCustomError(controller, "InsufficientValue");
+
+    // Test that run SQL on table is gated by ether (with revert/require)
+    await expect(
+      tables.connect(caller).runSQL(caller.address, tableId, runStatement, {
+        value: ethers.utils.parseEther("2"),
+      })
+    ).to.be.revertedWith("too much ether!");
 
     // Test that run SQL on table is gated by Foo and Bar ownership
     const value = ethers.utils.parseEther("1");
@@ -367,6 +383,121 @@ describe("ITablelandController", function () {
       BigNumber.from(0)
     );
     expect(await ethers.provider.getBalance(controller.address)).to.equal(
+      value
+    );
+
+    // Mint some more
+    tx = await foos.connect(caller).mint();
+    await tx.wait();
+    tx = await bars.connect(caller).mint();
+    await tx.wait();
+    tx = await bars.connect(caller).mint();
+    await tx.wait();
+
+    // Where clause should reflect all owned tokens
+    tx = await tables
+      .connect(caller)
+      .runSQL(caller.address, tableId, runStatement, { value });
+    receipt = await tx.wait();
+    [runEvent] = receipt.events ?? [];
+    expect(runEvent.args!.caller).to.equal(caller.address);
+    expect(runEvent.args!.isOwner).to.equal(false);
+    expect(runEvent.args!.tableId).to.equal(tableId);
+    expect(runEvent.args!.statement).to.equal(runStatement);
+    expect(runEvent.args!.policy.allowInsert).to.equal(false);
+    expect(runEvent.args!.policy.allowUpdate).to.equal(true);
+    expect(runEvent.args!.policy.allowDelete).to.equal(false);
+    expect(runEvent.args!.policy.whereClause).to.equal(
+      "foo_id in(0,1) and bar_id in(0,1,2)"
+    );
+    expect(runEvent.args!.policy.withCheck).to.equal("baz > 0");
+    expect(runEvent.args!.policy.updatableColumns.length).to.equal(1);
+    expect(runEvent.args!.policy.updatableColumns).to.include("baz");
+  });
+
+  it("Should be able to gate run SQL with controller v0 contract", async function () {
+    const owner = accounts[4];
+    let tx = await tables.createTable(
+      owner.address,
+      "create table testing (int a);"
+    );
+    let receipt = await tx.wait();
+    const [, createEvent] = receipt.events ?? [];
+    const tableId = createEvent.args!.tableId;
+    tx = await tables
+      .connect(owner)
+      .setController(owner.address, tableId, controllerV0.address);
+    await tx.wait();
+
+    // Test that run SQL on table is gated by ether
+    const runStatement = "insert into testing values (0);";
+    const caller = accounts[5];
+    await expect(
+      tables.connect(caller).runSQL(caller.address, tableId, runStatement)
+    ).to.be.revertedWithCustomError(controllerV0, "InsufficientValue");
+
+    // Test that run SQL on table is gated by Foo and Bar ownership
+    const value = ethers.utils.parseEther("1");
+    await expect(
+      tables.connect(caller).runSQL(caller.address, tableId, runStatement, {
+        value,
+      })
+    ).to.be.revertedWithCustomError(
+      enumPolicyLib,
+      "ERC721EnumerablePoliciesUnauthorized"
+    );
+
+    // Test balance was reverted
+    expect(await ethers.provider.getBalance(tables.address)).to.equal(
+      BigNumber.from(0)
+    );
+    expect(await ethers.provider.getBalance(controllerV0.address)).to.equal(
+      BigNumber.from(0)
+    );
+
+    // Mint a Foo
+    tx = await foos.connect(caller).mint();
+    await tx.wait();
+
+    // Still gated (need a Bar too)
+    await expect(
+      tables.connect(caller).runSQL(caller.address, tableId, runStatement, {
+        value,
+      })
+    ).to.be.revertedWithCustomError(
+      queryablePolicyLib,
+      "ERC721AQueryablePoliciesUnauthorized"
+    );
+
+    // Mint a Bar
+    tx = await bars.connect(caller).mint();
+    await tx.wait();
+
+    // Caller should be able to run SQL now
+    tx = await tables
+      .connect(caller)
+      .runSQL(caller.address, tableId, runStatement, { value });
+    receipt = await tx.wait();
+    let [runEvent] = receipt.events ?? [];
+    expect(runEvent.args!.caller).to.equal(caller.address);
+    expect(runEvent.args!.isOwner).to.equal(false);
+    expect(runEvent.args!.tableId).to.equal(tableId);
+    expect(runEvent.args!.statement).to.equal(runStatement);
+    expect(runEvent.args!.policy.allowInsert).to.equal(false);
+    expect(runEvent.args!.policy.allowUpdate).to.equal(true);
+    expect(runEvent.args!.policy.allowDelete).to.equal(false);
+    expect(runEvent.args!.policy.whereClause).to.equal(
+      "foo_id in(0) and bar_id in(0)"
+    );
+    expect(runEvent.args!.policy.withCheck).to.equal("baz > 0");
+    expect(runEvent.args!.policy.updatableColumns.length).to.equal(1);
+    expect(runEvent.args!.policy.updatableColumns).to.include("baz");
+
+    // Test balance was taken by controller
+    expect(await ethers.provider.getBalance(tables.address)).to.equal(
+      BigNumber.from(0)
+    );
+    expect(await ethers.provider.getBalance(controllerV0.address)).to.equal(
       value
     );
 


### PR DESCRIPTION
@awmuncy @joewagner, while reviewing @awmuncy 's PR this afternoon, I started to feel how annoying it would be to always include a version method. I played around with providing an abstract contract that people can use, but it adds more lines to controller contracts, and using it would not be obvious.

I started wondering if for sure we can't just catch the error returned by calling a method that doesn't exist on a contract. Take a look at this approach. It started just playing around, but I wanted to get the idea across which ended up taking it pretty far.

Additionally, there's a test that uses an exact copy of the original controller to ensure that contracts out in the wild today would be backwards compatible. Specifically, this tests if an existing contract's old `ITablelandController.Policy` type is correctly "cast" into the new `TablelandPolicy` type.