### PR TITLE
add constructor with call to _disableInitializers

### DIFF
--- a/contracts/TablelandTables.sol
+++ b/contracts/TablelandTables.sol
@@ -32,6 +32,11 @@ contract TablelandTables is
     // The maximum size allowed for a query.
     uint256 internal constant QUERY_MAX_SIZE = 35000;
 
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor() {
+        _disableInitializers();
+    }
+
     function initialize(
         string memory baseURI
     ) public initializerERC721A initializer {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "clean": "hardhat clean && rm -rf artifacts && rm -rf typechain-types && rm -rf cache && rm -rf coverage && rm -f coverage.json && rm -f network.js* && rm -f network.d*",
     "up": "npm install && npx hardhat compile && npm run build && hardhat node",
     "test": "npm run test:unit && npm run test:e2e",
-    "test:unit": "hardhat coverage --testfiles \"test/unit\" && istanbul check-coverage ./coverage.json --statements 100 --branches 96 --functions 100 --lines 100",
+    "test:unit": "hardhat coverage --testfiles \"test/unit\" && istanbul check-coverage ./coverage.json --statements 100 --branches 98 --functions 100 --lines 100",
     "test:e2e": "node --experimental-fetch ./node_modules/mocha/bin/mocha.js --exit test/integration",
     "test:gas": "REPORT_GAS=true hardhat test",
     "lint": "eslint '**/*.{js,ts}'",

--- a/scripts/initialize.ts
+++ b/scripts/initialize.ts
@@ -1,0 +1,45 @@
+// Note: This script was added to manually initialize live implementation
+// contracts before a constructor was added to TablelandTables with a call
+// to _disableInitializers(). This disables calls to initialize on the
+// implementation, making this script unnecessary after the next upgrade.
+
+import { ethers, network, baseURI, proxy, upgrades } from "hardhat";
+
+async function main() {
+  console.log(`\nInitializing on '${network.name}'...`);
+
+  // Get proxy owner account
+  const [account] = await ethers.getSigners();
+  if (account.provider === undefined) {
+    throw Error("missing provider");
+  }
+
+  // Get proxy address
+  if (proxy === undefined || proxy === "") {
+    throw Error(`missing proxies entry for '${network.name}'`);
+  }
+  console.log(`Using proxy address '${proxy}'`);
+
+  // Get implementation address
+  const impl = await upgrades.erc1967.getImplementationAddress(proxy);
+  console.log("Implementation address:", impl);
+
+  // Get new base URI
+  if (baseURI === undefined || baseURI === "") {
+    throw Error(`missing baseURIs entry for '${network.name}'`);
+  }
+  console.log(`Using base URI '${baseURI}'`);
+
+  // Initialize
+  const tables = (await ethers.getContractFactory("TablelandTables")).attach(
+    impl
+  );
+  const tx = await tables.initialize(baseURI);
+  const receipt = await tx.wait();
+  console.log(`initialized with tx '${receipt.transactionHash}'`);
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/test/unit/ITablelandController.ts
+++ b/test/unit/ITablelandController.ts
@@ -2,7 +2,7 @@ import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
 import { BigNumber } from "ethers";
-import { ethers } from "hardhat";
+import { ethers, upgrades } from "hardhat";
 import type {
   TablelandTables,
   TestERC721Enumerable,
@@ -30,11 +30,12 @@ describe("ITablelandController", function () {
     accounts = await ethers.getSigners();
 
     // Deploy tables
-    tables = (await (
-      await ethers.getContractFactory("TablelandTables")
-    ).deploy()) as TablelandTables;
-    await tables.deployed();
-    await (await tables.initialize("https://foo.xyz/")).wait();
+    const Factory = await ethers.getContractFactory("TablelandTables");
+    tables = await (
+      (await upgrades.deployProxy(Factory, ["https://foo.xyz/"], {
+        kind: "uups",
+      })) as TablelandTables
+    ).deployed();
 
     // Deploy test erc721 contracts
     foos = (await (

--- a/test/unit/TablelandTables.ts
+++ b/test/unit/TablelandTables.ts
@@ -2,7 +2,7 @@ import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
 import { BigNumber } from "ethers";
-import { ethers } from "hardhat";
+import { ethers, upgrades } from "hardhat";
 import { TablelandTables } from "../../typechain-types";
 
 chai.use(chaiAsPromised);
@@ -15,15 +15,11 @@ describe("TablelandTables", function () {
   beforeEach(async function () {
     accounts = await ethers.getSigners();
     const Factory = await ethers.getContractFactory("TablelandTables");
-    tables = (await Factory.deploy()) as TablelandTables;
-    await tables.deployed();
-    await (await tables.initialize("https://foo.xyz/")).wait();
-  });
-
-  it("Should not be initializable more than once", async function () {
-    await expect(tables.initialize("https://foo.xyz/")).to.be.revertedWith(
-      "ERC721A__Initializable: contract is already initialized"
-    );
+    tables = await (
+      (await upgrades.deployProxy(Factory, ["https://foo.xyz/"], {
+        kind: "uups",
+      })) as TablelandTables
+    ).deployed();
   });
 
   it("Should have set owner to deployer address", async function () {


### PR DESCRIPTION
See here for description of the issue: https://forum.openzeppelin.com/t/uupsupgradeable-vulnerability-post-mortem/15680.

See here for use of _disableInitializers: https://forum.openzeppelin.com/t/what-does-disableinitializers-function-mean/28730/2

See here for method def: https://docs.openzeppelin.com/contracts/4.x/api/proxy#Initializable-_disableInitializers--.

A hotfix for the core issues was added in Contracts 4.3.2 (https://forum.openzeppelin.com/t/uupsupgradeable-vulnerability-post-mortem/15680#hotfix-4). Our contracts are all > 4.5.0. Contracts 4.6.0 added _disableInitializers which removes the ability to call initialize on implementations, even though it's not really an issue anymore.

The usage here is taken from the OZ contract wizard.