### PR TITLE
Gas Optimizations

### DIFF
--- a/contracts/TablelandTables.sol
+++ b/contracts/TablelandTables.sol
@@ -78,11 +78,15 @@ contract TablelandTables is
         address owner,
         string[] calldata statements
     ) external payable override whenNotPaused returns (uint256[] memory) {
-        if (statements.length < 1) revert Unauthorized();
+        uint256 statementsLength = statements.length;
+        if (statementsLength < 1) revert Unauthorized();
 
-        uint256[] memory tableIds = new uint256[](statements.length);
-        for (uint256 i = 0; i < statements.length; i++) {
+        uint256[] memory tableIds = new uint256[](statementsLength);
+        for (uint256 i; i < statementsLength;) {
             tableIds[i] = _create(owner, statements[i]);
+            unchecked {
+                ++i;
+            }
         }
 
         return tableIds;
@@ -118,8 +122,12 @@ contract TablelandTables is
         address caller,
         ITablelandTables.Statement[] calldata statements
     ) external payable override whenNotPaused nonReentrant {
-        for (uint256 i = 0; i < statements.length; i++) {
+        uint256 statementsLength = statements.length;
+        for (uint256 i; i < statementsLength;) {
             _mutate(caller, statements[i].tableId, statements[i].statement);
+            unchecked {
+                ++i;
+            }
         }
     }
 

--- a/contracts/TablelandTables.sol
+++ b/contracts/TablelandTables.sol
@@ -30,7 +30,7 @@ contract TablelandTables is
     // A mapping of table controller addresses to lock status.
     mapping(uint256 => bool) internal _locks;
     // The maximum size allowed for a query.
-    uint256 internal constant QUERY_MAX_SIZE = 35000;
+    uint256 internal constant QUERY_MAX_SIZE = 35001;
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor() {
@@ -82,7 +82,7 @@ contract TablelandTables is
         if (statementsLength < 1) revert Unauthorized();
 
         uint256[] memory tableIds = new uint256[](statementsLength);
-        for (uint256 i; i < statementsLength;) {
+        for (uint256 i; i < statementsLength; ) {
             tableIds[i] = _create(owner, statements[i]);
             unchecked {
                 ++i;
@@ -123,7 +123,7 @@ contract TablelandTables is
         ITablelandTables.Statement[] calldata statements
     ) external payable override whenNotPaused nonReentrant {
         uint256 statementsLength = statements.length;
-        for (uint256 i; i < statementsLength;) {
+        for (uint256 i; i < statementsLength; ) {
             _mutate(caller, statements[i].tableId, statements[i].statement);
             unchecked {
                 ++i;
@@ -152,7 +152,7 @@ contract TablelandTables is
             revert Unauthorized();
 
         uint256 querySize = bytes(statement).length;
-        if (querySize > QUERY_MAX_SIZE)
+        if (querySize >= QUERY_MAX_SIZE)
             revert MaxQuerySizeExceeded(querySize, QUERY_MAX_SIZE);
 
         emit RunSQL(


### PR DESCRIPTION
- Cache frequently accessed function param in `for` loops
- Switch `i` to unchecked as it'll always be less than `statements.length` which is checked.
- Use `>=` instead of `>` as it is cheaper.

Prev
| Contract          | Method | Min   | Max   | Avg   | # calls |
|-------------------|--------|-------|-------|-------|---------|
| TablelandTables   | create | 99446 | 114046| 106746| 4       | 
|  TablelandTables  | mutate | 58652 | 62652 | 59985 | 6       |


New
| Contract          | Method | Min   | Max   | Avg    | # calls |
|-------------------|--------|-------|-------|--------|---------|
| TablelandTables   | create | 99315 | 113915| 106615 | 4       |
|  TablelandTables  | mutate | 58515 | 62515 | 59848  | 6       |


Diff
| Contract          | Method | Min Diff | Max Diff | Avg Diff | # calls Diff | 
|-------------------|--------|---------|---------|----------|--------------|
| TablelandTables   | create | -131    | -131    | -131     | 0            | 
| TablelandTables   | mutate | -137    | -137    | -137     | 0            | 
