### PR TITLE
allow setting `allowUnlimitedContractSize` via env

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -191,6 +191,8 @@ const config: HardhatUserConfig = {
         auto: !(process.env.HARDHAT_DISABLE_AUTO_MINING === "true"),
         interval: [100, 3000],
       },
+      allowUnlimitedContractSize:
+        process.env.HARDHAT_UNLIMITED_CONTRACT_SIZE === "true",
     },
   },
   baseURIs,


### PR DESCRIPTION
This PR in combination with https://github.com/tablelandnetwork/local-tableland/pull/296 enables a local dev network to deploy the contract regardless of contract size.  This is useful as a means to explore size limitations and underlying issues that affect the deployed contract's size.