### PR TITLE
fix: base URI for Filecoin Hyperspace

### DIFF
--- a/network.ts
+++ b/network.ts
@@ -59,7 +59,8 @@ export const baseURIs: TablelandNetworkConfig = {
   "optimism-goerli": "https://testnets.tableland.network/api/v1/tables/420/",
   "arbitrum-goerli": "https://testnets.tableland.network/api/v1/tables/421613/",
   maticmum: "https://testnets.tableland.network/api/v1/tables/80001/",
-  "filecoin-hyperspace": "https://testnets.tableland.network/api/v1/tables/3141/",
+  "filecoin-hyperspace":
+    "https://testnets.tableland.network/api/v1/tables/3141/",
   "optimism-goerli-staging":
     "https://staging.tableland.network/api/v1/tables/420/",
   localhost: localTablelandURI,

--- a/network.ts
+++ b/network.ts
@@ -59,7 +59,7 @@ export const baseURIs: TablelandNetworkConfig = {
   "optimism-goerli": "https://testnets.tableland.network/api/v1/tables/420/",
   "arbitrum-goerli": "https://testnets.tableland.network/api/v1/tables/421613/",
   maticmum: "https://testnets.tableland.network/api/v1/tables/80001/",
-  "filecoin-hyperspace": "https://tableland.network/api/v1/tables/3141/",
+  "filecoin-hyperspace": "https://testnets.tableland.network/api/v1/tables/3141/",
   "optimism-goerli-staging":
     "https://staging.tableland.network/api/v1/tables/420/",
   localhost: localTablelandURI,


### PR DESCRIPTION
## Summary

The current `baseURI` value for `filecoin-hyperspace` points to the mainnets gateway, not testnets, which also affects downstream clients like the SDK's `isTestnet` utility method and others.

## Details

Idk all of the implications as I wanted to get this out quickly, but I'd assume SDK / CLI methods that try to use Hyperspace will have issues when reading from the wrong gateway. Note that our FVM hackathon is starting next week, and I have a Hyperspace demo _tomorrow_.

## How it was tested

Using `npm run test`.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
