### PR TITLE
Move @openzeppelin/contracts from being a devDependency to a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,12 +8,14 @@
       "name": "@tableland/evm",
       "version": "0.0.0",
       "license": "MIT AND Apache-2.0",
+      "dependencies": {
+        "@openzeppelin/contracts": "4.8.3"
+      },
       "devDependencies": {
         "@ethersproject/providers": "^5.7.2",
         "@nomicfoundation/hardhat-chai-matchers": "^1.0.6",
         "@nomiclabs/hardhat-ethers": "^2.2.2",
         "@nomiclabs/hardhat-etherscan": "^3.1.7",
-        "@openzeppelin/contracts": "4.8.3",
         "@openzeppelin/contracts-upgradeable": "4.8.3",
         "@openzeppelin/hardhat-upgrades": "^1.22.1",
         "@tableland/local": "^1.1.0",
@@ -1527,8 +1529,7 @@
     "node_modules/@openzeppelin/contracts": {
       "version": "4.8.3",
       "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-4.8.3.tgz",
-      "integrity": "sha512-bQHV8R9Me8IaJoJ2vPG4rXcL7seB7YVuskr4f+f5RyOStSZetwzkWtoqDMl5erkBJy0lDRUnIR2WIkPiC0GJlg==",
-      "dev": true
+      "integrity": "sha512-bQHV8R9Me8IaJoJ2vPG4rXcL7seB7YVuskr4f+f5RyOStSZetwzkWtoqDMl5erkBJy0lDRUnIR2WIkPiC0GJlg=="
     },
     "node_modules/@openzeppelin/contracts-upgradeable": {
       "version": "4.8.3",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "@nomicfoundation/hardhat-chai-matchers": "^1.0.6",
     "@nomiclabs/hardhat-ethers": "^2.2.2",
     "@nomiclabs/hardhat-etherscan": "^3.1.7",
-    "@openzeppelin/contracts": "4.8.3",
     "@openzeppelin/contracts-upgradeable": "4.8.3",
     "@openzeppelin/hardhat-upgrades": "^1.22.1",
     "@tableland/local": "^1.1.0",
@@ -95,5 +94,8 @@
     "ts-node": "^10.9.1",
     "typechain": "^8.1.1",
     "typescript": "^5.0.2"
+  },
+  "dependencies": {
+    "@openzeppelin/contracts": "4.8.3"
   }
 }


### PR DESCRIPTION
The `SQLHelpers` contract depends on @openzeppelin/contracts/utils/Strings.sol so I think we should list that as a dependency, not just a dev dependency.

As a package consumer I would expect that I should be able to
```
npm install @tableland/evm
```
and then
```solidity
import "@tableland/evm/contracts/utils/SQLHelpers.sol";
```
in my contract without errors