### PR TITLE
fix: use interface over imported registry in deployments helper

### DIFF
--- a/contracts/utils/TablelandDeployments.sol
+++ b/contracts/utils/TablelandDeployments.sol
@@ -1,7 +1,10 @@
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.10 <0.9.0;
 
-import {TablelandTables} from "../TablelandTables.sol";
+import {ITablelandTables} from "../interfaces/ITablelandTables.sol";
+import {IERC721AUpgradeable} from "erc721a-upgradeable/contracts/IERC721AUpgradeable.sol";
+
+interface TablelandTablesImpl is ITablelandTables, IERC721AUpgradeable {}
 
 /**
  * @dev Helper library for getting an instance of ITablelandTables for the currently executing EVM chain.
@@ -62,31 +65,31 @@ library TablelandDeployments {
      *
      * - block.chainid must refer to a supported chain.
      */
-    function get() internal view returns (TablelandTables) {
+    function get() internal view returns (TablelandTablesImpl) {
         if (block.chainid == 1) {
-            return TablelandTables(MAINNET);
+            return TablelandTablesImpl(MAINNET);
         } else if (block.chainid == 10) {
-            return TablelandTables(OPTIMISM);
+            return TablelandTablesImpl(OPTIMISM);
         } else if (block.chainid == 42161) {
-            return TablelandTables(ARBITRUM);
+            return TablelandTablesImpl(ARBITRUM);
         } else if (block.chainid == 42170) {
-            return TablelandTables(ARBITRUM_NOVA);
+            return TablelandTablesImpl(ARBITRUM_NOVA);
         } else if (block.chainid == 137) {
-            return TablelandTables(MATIC);
+            return TablelandTablesImpl(MATIC);
         } else if (block.chainid == 314) {
-            return TablelandTables(FILECOIN);
+            return TablelandTablesImpl(FILECOIN);
         } else if (block.chainid == 11155111) {
-            return TablelandTables(SEPOLIA);
+            return TablelandTablesImpl(SEPOLIA);
         } else if (block.chainid == 420) {
-            return TablelandTables(OPTIMISM_GOERLI);
+            return TablelandTablesImpl(OPTIMISM_GOERLI);
         } else if (block.chainid == 421614) {
-            return TablelandTables(ARBITRUM_SEPOLIA);
+            return TablelandTablesImpl(ARBITRUM_SEPOLIA);
         } else if (block.chainid == 80001) {
-            return TablelandTables(MATICMUM);
+            return TablelandTablesImpl(MATICMUM);
         } else if (block.chainid == 314159) {
-            return TablelandTables(FILECOIN_CALIBRATION);
+            return TablelandTablesImpl(FILECOIN_CALIBRATION);
         } else if (block.chainid == 31337) {
-            return TablelandTables(LOCAL_TABLELAND);
+            return TablelandTablesImpl(LOCAL_TABLELAND);
         } else {
             revert ChainNotSupported(block.chainid);
         }


### PR DESCRIPTION
## Summary

Alters `TablelandDeployments` to use a wrapper/interface around the `ITablelandTables` and `IERC721AUpgradeable` contracts, enabling the same functionality while resolving potential dependency issues. Originally noted [here](https://discord.com/channels/592843512312102924/1182526235511902240/1182760451034071090) and [here](https://discord.com/channels/592843512312102924/1049526583452512359/1187408350049226792) (happened to at least two developers).

## Details

Currently, the `TablelandDeployments` contract imports `TablelandTables`, which is an OpenZeppelin `OwnableUpgradeable` contract. This can cause issues because, for example, Remix installs dependencies but doesn't resolve peer-dependencies by grabbing the version the first library depends on—it just resolves to the latest version. With OZ's v5 release, the `OwnableUpgradeable` contract has breaking changes, as do some others like `PausableUpgradeable` that now exist in different package path.

Remix is still a highly used entrypoint for developers testing out smart contracts, so making things fully compatible here makes sense. Alternatively, we could change `TablelandTables` to use OZ v5 contracts, but the `TablelandDeployments` change seems easier.

## How it was tested

- Existing tests passed.
- Tested out with example contract in Remix.

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
