### PR TITLE
mark ethers as a package dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,15 @@
       "version": "0.0.0",
       "license": "MIT AND Apache-2.0",
       "dependencies": {
-        "@openzeppelin/contracts": "4.9.6"
+        "@openzeppelin/contracts": "4.9.6",
+        "ethers": "^6.12.0"
       },
       "devDependencies": {
         "@nomicfoundation/hardhat-chai-matchers": "^2.0.6",
-        "@nomicfoundation/hardhat-ethers": "^3.0.5",
+        "@nomicfoundation/hardhat-ethers": "^3.0.6",
         "@nomicfoundation/hardhat-verify": "^2.0.5",
         "@openzeppelin/contracts-upgradeable": "4.9.6",
-        "@openzeppelin/hardhat-upgrades": "^3.0.5",
+        "@openzeppelin/hardhat-upgrades": "^3.1.0",
         "@tableland/local": "^3.0.0-pre.1",
         "@tableland/sdk": "^7.0.0-pre.0",
         "@typechain/ethers-v6": "^0.5.1",
@@ -38,7 +39,6 @@
         "eslint-plugin-import": "^2.27.5",
         "eslint-plugin-n": "^15.6.1",
         "eslint-plugin-promise": "^6.1.1",
-        "ethers": "^6.12.0",
         "hardhat": "^2.22.2",
         "hardhat-contract-sizer": "^2.10.0",
         "hardhat-gas-reporter": "^2.1.1",
@@ -58,8 +58,7 @@
     "node_modules/@adraffy/ens-normalize": {
       "version": "1.10.1",
       "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
-      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
-      "dev": true
+      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw=="
     },
     "node_modules/@async-generators/from-emitter": {
       "version": "0.3.0",
@@ -1217,7 +1216,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
       "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
-      "dev": true,
       "dependencies": {
         "@noble/hashes": "1.3.2"
       },
@@ -1229,7 +1227,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
       "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
-      "dev": true,
       "engines": {
         "node": ">= 16"
       },
@@ -1544,9 +1541,9 @@
       }
     },
     "node_modules/@nomicfoundation/hardhat-ethers": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ethers/-/hardhat-ethers-3.0.5.tgz",
-      "integrity": "sha512-RNFe8OtbZK6Ila9kIlHp0+S80/0Bu/3p41HUpaRIoHLm6X3WekTd83vob3rE54Duufu1edCiBDxspBzi2rxHHw==",
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-ethers/-/hardhat-ethers-3.0.6.tgz",
+      "integrity": "sha512-/xzkFQAaHQhmIAYOQmvHBPwL+NkwLzT9gRZBsgWUYeV+E6pzXsBQsHfRYbAZ3XEYare+T7S+5Tg/1KDJgepSkA==",
       "dev": true,
       "dependencies": {
         "debug": "^4.1.1",
@@ -1876,9 +1873,9 @@
       }
     },
     "node_modules/@openzeppelin/hardhat-upgrades": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/hardhat-upgrades/-/hardhat-upgrades-3.0.5.tgz",
-      "integrity": "sha512-7Klg1B6fH45+7Zxzr6d9mLqudrL9Uk6CUG5AeG5NckPfP4ZlQRo1squcQ8yJPwqDS8rQjfChiqKDelp4LTjyZQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/hardhat-upgrades/-/hardhat-upgrades-3.1.0.tgz",
+      "integrity": "sha512-CQ5Cg2kE8WeW6qajUTacBsmkntiAwJd7f6p+BUtd1fEvEv7si4H2lmAqvjOjkFc9ihIEQxMBy50IsBXSZGktmg==",
       "dev": true,
       "dependencies": {
         "@openzeppelin/defender-admin-client": "^1.52.0",
@@ -1891,7 +1888,7 @@
         "debug": "^4.1.1",
         "ethereumjs-util": "^7.1.5",
         "proper-lockfile": "^4.1.1",
-        "undici": "^6.0.0"
+        "undici": "^6.11.1"
       },
       "bin": {
         "migrate-oz-cli-project": "dist/scripts/migrate-oz-cli-project.js"
@@ -3156,8 +3153,7 @@
     "node_modules/aes-js": {
       "version": "4.0.0-beta.5",
       "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
-      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
-      "dev": true
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q=="
     },
     "node_modules/agent-base": {
       "version": "6.0.2",
@@ -5488,7 +5484,6 @@
       "version": "6.12.0",
       "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.12.0.tgz",
       "integrity": "sha512-zL5NlOTjML239gIvtVJuaSk0N9GQLi1Hom3ZWUszE5lDTQE/IVB62mrPkQ2W1bGcZwVGSLaetQbWNQSvI4rGDQ==",
-      "dev": true,
       "funding": [
         {
           "type": "individual",
@@ -5516,7 +5511,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
       "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
-      "dev": true,
       "engines": {
         "node": ">= 16"
       },
@@ -5527,20 +5521,17 @@
     "node_modules/ethers/node_modules/@types/node": {
       "version": "18.15.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.13.tgz",
-      "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q==",
-      "dev": true
+      "integrity": "sha512-N+0kuo9KgrUQ1Sn/ifDXsvg0TTleP7rIy4zOBGECxAljqvqfqpTfzx0Q1NUedOixRMBfe2Whhb056a42cWs26Q=="
     },
     "node_modules/ethers/node_modules/tslib": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
-      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
-      "dev": true
+      "integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ=="
     },
     "node_modules/ethers/node_modules/ws": {
       "version": "8.5.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
       "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
-      "dev": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -56,10 +56,10 @@
   "homepage": "https://github.com/tablelandnetwork/evm-tableland#readme",
   "devDependencies": {
     "@nomicfoundation/hardhat-chai-matchers": "^2.0.6",
-    "@nomicfoundation/hardhat-ethers": "^3.0.5",
+    "@nomicfoundation/hardhat-ethers": "^3.0.6",
     "@nomicfoundation/hardhat-verify": "^2.0.5",
     "@openzeppelin/contracts-upgradeable": "4.9.6",
-    "@openzeppelin/hardhat-upgrades": "^3.0.5",
+    "@openzeppelin/hardhat-upgrades": "^3.1.0",
     "@tableland/local": "^3.0.0-pre.1",
     "@tableland/sdk": "^7.0.0-pre.0",
     "@typechain/ethers-v6": "^0.5.1",
@@ -81,7 +81,6 @@
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-n": "^15.6.1",
     "eslint-plugin-promise": "^6.1.1",
-    "ethers": "^6.12.0",
     "hardhat": "^2.22.2",
     "hardhat-contract-sizer": "^2.10.0",
     "hardhat-gas-reporter": "^2.1.1",
@@ -95,6 +94,7 @@
     "typescript": "^5.0.2"
   },
   "dependencies": {
-    "@openzeppelin/contracts": "4.9.6"
+    "@openzeppelin/contracts": "4.9.6",
+    "ethers": "^6.12.0"
   }
 }


### PR DESCRIPTION
## Overview
Ethers is currently a devDep, but in order to build with typescript this package must have the correct ethers version. This means any package using this and a different version of ethers will not build correctly.

## Details
A user reported an issue using ethers v5 and v6 in the same packages here: https://discord.com/channels/592843512312102924/968582612945870878/1242050427982315645
The fix involves publishing a version of this package with ethers as a dep, and then publishing a version of the sdk that uses the new version of this package.  

If anyone wants to test this out, I published `next` tagged versions for both today.
https://www.npmjs.com/package/@tableland/sdk?activeTab=versions
https://www.npmjs.com/package/@tableland/evm?activeTab=versions

The user who reported the issue has a small test app you can use here:
https://github.com/mlegls/tableland-ethers-5-demo/tree/main
