### PR TITLE
add the solidity plugin to the prettier config

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,4 +1,5 @@
 {
   "semi": true,
-  "trailingComma": "es5"
+  "trailingComma": "es5",
+  "plugins": ["prettier-plugin-solidity"]
 }


### PR DESCRIPTION
While reviewing a PR I noticed that we have the prettier Solidity plugin installed, but it isn't being used by prettier.
This adds the plugin to the prettier config.